### PR TITLE
simplify div1 logic

### DIFF
--- a/Ghidra/Processors/SuperH/data/languages/superh.sinc
+++ b/Ghidra/Processors/SuperH/data/languages/superh.sinc
@@ -1034,11 +1034,11 @@ MovMUReg2: MovMUReg2_15 is MovMUReg2_15 {
     
     tmp0 = rn_08_11;
     # rn_08_11 = old_q_eq_m ? rn_08_11 - tmp2 : rn_08_11 + tmp2;
-    rn_08_11 = (sext(old_q_eq_m) & (rn_08_11 - tmp2)) | (sext(!old_q_eq_m) & (rn_08_11 + tmp2));
+    rn_08_11 = (sext(old_q_eq_m) & (rn_08_11 - tmp2)) | (sext(~old_q_eq_m) & (rn_08_11 + tmp2));
     # tmp1 = old_q_eq_m ? rn_08_11 > tmp0 : rn_08_11 < tmp0;
-    tmp1 = (sext(old_q_eq_m) & (rn_08_11 > tmp0)) | (sext(!old_q_eq_m) & (rn_08_11 < tmp0));
+    tmp1 = (old_q_eq_m & (rn_08_11 > tmp0)) | (~old_q_eq_m & (rn_08_11 < tmp0));
     # $(Q_FLAG) = m_eq_q ? tmp1 : tmp1 == 0;
-    $(Q_FLAG) = (sext(m_eq_q) & tmp1) | (sext(!m_eq_q) & (tmp1 == 0));
+    $(Q_FLAG) = (m_eq_q & tmp1) | (~m_eq_q & (tmp1 == 0));
 
     $(T_FLAG) = $(Q_FLAG) == $(M_FLAG);
 }

--- a/Ghidra/Processors/SuperH/data/languages/superh.sinc
+++ b/Ghidra/Processors/SuperH/data/languages/superh.sinc
@@ -1021,74 +1021,25 @@ MovMUReg2: MovMUReg2_15 is MovMUReg2_15 {
     local tmp1:1;
     local tmp2:4;
     local old_q:1;
+    local old_q_eq_m:1;
+    local m_eq_q:1;
     
     old_q = $(Q_FLAG);
     $(Q_FLAG) = (0x80000000 & rn_08_11) != 0;
     tmp2 = rm_04_07;
     rn_08_11 = rn_08_11 << 1;
     rn_08_11 = rn_08_11 | zext($(T_FLAG));
+    old_q_eq_m = old_q == $(M_FLAG);
+    m_eq_q = $(M_FLAG) == $(Q_FLAG);
     
-    # FIXME: cleaner way to do this??
     tmp0 = rn_08_11;
-    
-    if(old_q == 0 && $(M_FLAG) == 0 && $(Q_FLAG) == 0) goto <OQ0_M0_Q0>;
-    if(old_q == 0 && $(M_FLAG) == 0 && $(Q_FLAG) == 1) goto <OQ0_M0_Q1>;
-    if(old_q == 0 && $(M_FLAG) == 1 && $(Q_FLAG) == 0) goto <OQ0_M1_Q0>;
-    if(old_q == 0 && $(M_FLAG) == 1 && $(Q_FLAG) == 1) goto <OQ0_M1_Q1>;
-    if(old_q == 1 && $(M_FLAG) == 0 && $(Q_FLAG) == 0) goto <OQ1_M0_Q0>;
-    if(old_q == 1 && $(M_FLAG) == 0 && $(Q_FLAG) == 1) goto <OQ1_M0_Q1>;
-    if(old_q == 1 && $(M_FLAG) == 1 && $(Q_FLAG) == 0) goto <OQ1_M1_Q0>;
-    if(old_q == 1 && $(M_FLAG) == 1 && $(Q_FLAG) == 1) goto <OQ1_M1_Q1>;
-    
-    <OQ0_M0_Q0>
-    rn_08_11 = rn_08_11 - tmp2;
-    tmp1 = rn_08_11 > tmp0;
-    $(Q_FLAG) = tmp1;
-    goto <SET_FLAG>;
-    
-    <OQ0_M0_Q1>
-    rn_08_11 = rn_08_11 - tmp2;
-    tmp1 = rn_08_11 > tmp0;
-    $(Q_FLAG) = tmp1 == 0;
-    goto <SET_FLAG>;
-    
-    <OQ0_M1_Q0>
-    rn_08_11 = rn_08_11 + tmp2;
-    tmp1 = rn_08_11 < tmp0;
-    $(Q_FLAG) = tmp1 == 0;
-    goto <SET_FLAG>;
-    
-    <OQ0_M1_Q1>
-    rn_08_11 = rn_08_11 + tmp2;
-    tmp1 = rn_08_11 < tmp0;
-    $(Q_FLAG) = tmp1;
-    goto <SET_FLAG>;
-    
-    <OQ1_M0_Q0>
-    rn_08_11 = rn_08_11 + tmp2;
-    tmp1 = rn_08_11 < tmp0;
-    $(Q_FLAG) = tmp1;
-    goto <SET_FLAG>;
-    
-    <OQ1_M0_Q1>
-    rn_08_11 = rn_08_11 + tmp2;
-    tmp1 = rn_08_11 < tmp0;
-    $(Q_FLAG) = tmp1;
-    goto <SET_FLAG>;
-    
-    <OQ1_M1_Q0>
-    rn_08_11 = rn_08_11 - tmp2;
-    tmp1 = rn_08_11 > tmp0;
-    $(Q_FLAG) = tmp1 == 0;
-    goto <SET_FLAG>;
-    
-    <OQ1_M1_Q1>
-    rn_08_11 = rn_08_11 - tmp2;
-    tmp1 = rn_08_11 > tmp0;
-    $(Q_FLAG) = tmp1;
-    goto <SET_FLAG>;
-    
-    <SET_FLAG>
+    # rn_08_11 = old_q_eq_m ? rn_08_11 - tmp2 : rn_08_11 + tmp2;
+    rn_08_11 = (sext(old_q_eq_m) & (rn_08_11 - tmp2)) | (sext(!old_q_eq_m) & (rn_08_11 + tmp2));
+    # tmp1 = old_q_eq_m ? rn_08_11 > tmp0 : rn_08_11 < tmp0;
+    tmp1 = (sext(old_q_eq_m) & (rn_08_11 > tmp0)) | (sext(!old_q_eq_m) & (rn_08_11 < tmp0));
+    # $(Q_FLAG) = m_eq_q ? tmp1 : tmp1 == 0;
+    $(Q_FLAG) = (sext(m_eq_q) & tmp1) | (sext(!m_eq_q) & (tmp1 == 0));
+
     $(T_FLAG) = $(Q_FLAG) == $(M_FLAG);
 }
 


### PR DESCRIPTION
The logic table for this is actually more condensed than the instruction summary makes it seem. This also fixes a bug in the previous code where $(Q_FLAG) was set incorrectly for the old_q = 1, M = 0, Q = 1 case.

Unfortunately I don't have a build setup for ghidra yet so I'm just verifying with my noggin. I will try to verify on a proper build soon.